### PR TITLE
Restore Plex and Jellyfin http listen ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,8 @@ services:
       TAILSCALE_HOSTNAME: mediaserver-plex
       TAILSCALE_SERVE_PORT: 32400
       TAILSCALE_FUNNEL: 1
+    ports:
+      - 127.0.0.1:32400:32400/tcp
     tmpfs:
       - /tmp
     volumes:
@@ -80,6 +82,8 @@ services:
       TAILSCALE_HOSTNAME: mediaserver-jellyfin
       TAILSCALE_SERVE_PORT: 8096
       TAILSCALE_FUNNEL: 1
+    ports:
+      - 127.0.0.1:8096:8096/tcp
     tmpfs:
       - /tmp
     volumes:


### PR DESCRIPTION
This reverts commit fd4437e8f58d6ad2490b79abe9e004896578f5b8.

These ports should still be available to localhost for tunnelling.

Change-type: patch