### PR TITLE
Move tailscale state to container tmpfs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,34 +3,21 @@ version: "2.1"
 volumes:
   downloads: {}
   duplicati: {}
-  duplicati-tailscale: {}
   jellyfin: {}
-  jellyfin-tailscale: {}
   letsencrypt: {}
   netdatalib: {}
   netdatacache: {}
   nzbhydra: {}
-  nzbhydra-tailscale: {}
   ombi: {}
-  ombi-tailscale: {}
   overseerr: {}
-  overseerr-tailscale: {}
   plex: {}
-  plex-tailscale: {}
   prowlarr: {}
-  prowlarr-tailscale: {}
   proxy: {}
-  nginx-tailscale: {}
   radarr: {}
-  radarr-tailscale: {}
   sabnzbd: {}
-  sabnzbd-tailscale: {}
   sonarr: {}
-  sonarr-tailscale: {}
   syncthing: {}
-  syncthing-tailscale: {}
   tautulli: {}
-  tautulli-tailscale: {}
 
 services:
   # https://docs.linuxserver.io/images/docker-plex
@@ -44,7 +31,7 @@ services:
     environment:
       PUID: "1000"
       PGID: "1000"
-      TAILSCALE_STATE_DIR: /var/lib/tailscale
+      TAILSCALE_STATE_DIR: /tmp/tailscale
       TAILSCALE_SERVE_MODE: https
       TAILSCALE_USE_SSH: 1
       TAILSCALE_HOSTNAME: plex
@@ -56,7 +43,6 @@ services:
     volumes:
       - plex:/config
       - downloads:/downloads
-      - plex-tailscale:/var/lib/tailscale
     entrypoint:
       - /bin/bash
       - -c
@@ -76,7 +62,7 @@ services:
     environment:
       PUID: "1000"
       PGID: "1000"
-      TAILSCALE_STATE_DIR: /var/lib/tailscale
+      TAILSCALE_STATE_DIR: /tmp/tailscale
       TAILSCALE_SERVE_MODE: https
       TAILSCALE_USE_SSH: 1
       TAILSCALE_HOSTNAME: jellyfin
@@ -88,7 +74,6 @@ services:
     volumes:
       - jellyfin:/config
       - downloads:/downloads
-      - jellyfin-tailscale:/var/lib/tailscale
     entrypoint:
       - /bin/bash
       - -c
@@ -106,7 +91,7 @@ services:
     environment:
       PUID: "1000"
       PGID: "1000"
-      TAILSCALE_STATE_DIR: /var/lib/tailscale
+      TAILSCALE_STATE_DIR: /tmp/tailscale
       TAILSCALE_SERVE_MODE: https
       TAILSCALE_USE_SSH: 1
       TAILSCALE_HOSTNAME: sonarr
@@ -118,7 +103,6 @@ services:
     volumes:
       - sonarr:/config
       - downloads:/downloads
-      - sonarr-tailscale:/var/lib/tailscale
     entrypoint:
       - /bin/bash
       - -c
@@ -136,7 +120,7 @@ services:
     environment:
       PUID: "1000"
       PGID: "1000"
-      TAILSCALE_STATE_DIR: /var/lib/tailscale
+      TAILSCALE_STATE_DIR: /tmp/tailscale
       TAILSCALE_SERVE_MODE: https
       TAILSCALE_USE_SSH: 1
       TAILSCALE_HOSTNAME: radarr
@@ -148,7 +132,6 @@ services:
     volumes:
       - radarr:/config
       - downloads:/downloads
-      - radarr-tailscale:/var/lib/tailscale
     entrypoint:
       - /bin/bash
       - -c
@@ -166,7 +149,7 @@ services:
     environment:
       PUID: "1000"
       PGID: "1000"
-      TAILSCALE_STATE_DIR: /var/lib/tailscale
+      TAILSCALE_STATE_DIR: /tmp/tailscale
       TAILSCALE_SERVE_MODE: https
       TAILSCALE_USE_SSH: 1
       TAILSCALE_HOSTNAME: prowlarr
@@ -178,7 +161,6 @@ services:
     volumes:
       - prowlarr:/config
       - downloads:/downloads
-      - prowlarr-tailscale:/var/lib/tailscale
     entrypoint:
       - /bin/bash
       - -c
@@ -196,7 +178,7 @@ services:
     environment:
       PUID: "1000"
       PGID: "1000"
-      TAILSCALE_STATE_DIR: /var/lib/tailscale
+      TAILSCALE_STATE_DIR: /tmp/tailscale
       TAILSCALE_SERVE_MODE: https
       TAILSCALE_USE_SSH: 1
       TAILSCALE_HOSTNAME: nzbhydra
@@ -208,7 +190,6 @@ services:
     volumes:
       - nzbhydra:/config
       - downloads:/downloads
-      - nzbhydra-tailscale:/var/lib/tailscale
     entrypoint:
       - /bin/bash
       - -c
@@ -226,7 +207,7 @@ services:
     environment:
       PUID: "1000"
       PGID: "1000"
-      TAILSCALE_STATE_DIR: /var/lib/tailscale
+      TAILSCALE_STATE_DIR: /tmp/tailscale
       TAILSCALE_SERVE_MODE: https
       TAILSCALE_USE_SSH: 1
       TAILSCALE_HOSTNAME: ombi
@@ -237,7 +218,6 @@ services:
       - /tmp
     volumes:
       - ombi:/config
-      - ombi-tailscale:/var/lib/tailscale
     entrypoint:
       - /bin/bash
       - -c
@@ -255,7 +235,7 @@ services:
     environment:
       PUID: "1000"
       PGID: "1000"
-      TAILSCALE_STATE_DIR: /var/lib/tailscale
+      TAILSCALE_STATE_DIR: /tmp/tailscale
       TAILSCALE_SERVE_MODE: https
       TAILSCALE_USE_SSH: 1
       TAILSCALE_HOSTNAME: overseerr
@@ -266,7 +246,6 @@ services:
       - /tmp
     volumes:
       - overseerr:/config
-      - overseerr-tailscale:/var/lib/tailscale
     entrypoint:
       - /bin/bash
       - -c
@@ -284,7 +263,7 @@ services:
     environment:
       PUID: "1000"
       PGID: "1000"
-      TAILSCALE_STATE_DIR: /var/lib/tailscale
+      TAILSCALE_STATE_DIR: /tmp/tailscale
       TAILSCALE_SERVE_MODE: https
       TAILSCALE_USE_SSH: 1
       TAILSCALE_HOSTNAME: sabnzbd
@@ -296,7 +275,6 @@ services:
     volumes:
       - sabnzbd:/config
       - downloads:/downloads
-      - sabnzbd-tailscale:/var/lib/tailscale
     entrypoint:
       - /bin/bash
       - -c
@@ -314,7 +292,7 @@ services:
     environment:
       PUID: "1000"
       PGID: "1000"
-      TAILSCALE_STATE_DIR: /var/lib/tailscale
+      TAILSCALE_STATE_DIR: /tmp/tailscale
       TAILSCALE_SERVE_MODE: https
       TAILSCALE_USE_SSH: 1
       TAILSCALE_HOSTNAME: tautulli
@@ -325,7 +303,6 @@ services:
       - /tmp
     volumes:
       - tautulli:/config
-      - sabnzbd-tailscale:/var/lib/tailscale
     entrypoint:
       - /bin/bash
       - -c
@@ -374,7 +351,7 @@ services:
     environment:
       PUID: "0"
       PGID: "0"
-      TAILSCALE_STATE_DIR: /var/lib/tailscale
+      TAILSCALE_STATE_DIR: /tmp/tailscale
       TAILSCALE_SERVE_MODE: https
       TAILSCALE_USE_SSH: 1
       TAILSCALE_HOSTNAME: duplicati
@@ -385,7 +362,6 @@ services:
       - /tmp
     volumes:
       - duplicati:/config
-      - duplicati-tailscale:/var/lib/tailscale
       # any volumes that might be worth backing up
       - syncthing:/volumes/syncthing
       - plex:/volumes/plex
@@ -417,7 +393,7 @@ services:
     environment:
       PUID: "1000"
       PGID: "1000"
-      TAILSCALE_STATE_DIR: /var/lib/tailscale
+      TAILSCALE_STATE_DIR: /tmp/tailscale
       TAILSCALE_SERVE_MODE: https
       TAILSCALE_USE_SSH: 1
       TAILSCALE_HOSTNAME: syncthing
@@ -431,7 +407,6 @@ services:
       - /tmp
     volumes:
       - syncthing:/config
-      - syncthing-tailscale:/var/lib/tailscale
       # any volumes that might be worth syncronizing between machines
       - plex:/volumes/plex
       - sonarr:/volumes/sonarr
@@ -462,7 +437,7 @@ services:
       dockerfile: Dockerfile.nginx-proxy-manager
     restart: "on-failure"
     environment:
-      TAILSCALE_STATE_DIR: /var/lib/tailscale
+      TAILSCALE_STATE_DIR: /tmp/tailscale
       TAILSCALE_SERVE_MODE: https
       TAILSCALE_USE_SSH: 1
       TAILSCALE_HOSTNAME: nginx
@@ -476,7 +451,6 @@ services:
     volumes:
       - proxy:/data
       - letsencrypt:/etc/letsencrypt
-      - nginx-tailscale:/var/lib/tailscale
     entrypoint:
       - /bin/bash
       - -c

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,12 @@ services:
       context: docker-mod
       dockerfile: Dockerfile.plex
     restart: "on-failure"
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+      - SYS_MODULE
+    labels:
+      io.balena.features.kernel-modules: 1
     devices:
       - /dev/dri:/dev/dri
     environment:

--- a/docker-mod/root/etc/s6-overlay/s6-rc.d/tailscale-up/run
+++ b/docker-mod/root/etc/s6-overlay/s6-rc.d/tailscale-up/run
@@ -5,6 +5,10 @@
 
 set -euo pipefail
 
+# handle unassigned variables
+TAILSCALE_USERSPACE="${TAILSCALE_USERSPACE:-true}"
+TAILSCALE_FUNNEL="${TAILSCALE_FUNNEL:-false}"
+
 FLAGS=""
 
 # configure `tailscale up`
@@ -15,16 +19,18 @@ else
 fi
 
 if [ -v TAILSCALE_HOSTNAME ]; then
+    echo "[!] using ${TAILSCALE_HOSTNAME} as hostname"
     FLAGS="${FLAGS} --hostname=${TAILSCALE_HOSTNAME}"
 fi
 
 if [ -v TAILSCALE_USE_SSH ]; then
+    echo '[!] enabling ssh'
     FLAGS="${FLAGS} --ssh=${TAILSCALE_USE_SSH}"
 fi
 
 if [ -v TAILSCALE_BE_EXIT_NODE ] && [ ! -v TAILSCALE_USE_EXIT_NODE ]; then
     echo '[!] acting as an exit node, you may need to approve this in the admin console'
-    FLAGS="${FLAGS} --advertise-exit-node=${TS_BE_EXIT_NODE}"
+    FLAGS="${FLAGS} --advertise-exit-node=${TAILSCALE_BE_EXIT_NODE}"
 fi
 
 # https://tailscale.com/kb/1241/tailscale-up/
@@ -39,7 +45,7 @@ tailscale up $FLAGS
 
 # configure serve or funnel
 if [ -v TAILSCALE_SERVE_PORT ] && [ -v TAILSCALE_SERVE_MODE ]; then
-    if [ -v TAILSCALE_FUNNEL ]; then
+    if [[ ${TAILSCALE_FUNNEL,,} =~ true|yes|on|1 ]]; then
         tailscale funnel --bg --"${TAILSCALE_SERVE_MODE}"=443 http://localhost:"${TAILSCALE_SERVE_PORT}"
     else
         tailscale serve --bg --"${TAILSCALE_SERVE_MODE}"=443 http://localhost:"${TAILSCALE_SERVE_PORT}"
@@ -48,7 +54,7 @@ fi
 
 # https://github.com/tailscale-dev/docker-mod/pull/8#issuecomment-1792262196
 # https://tailscale.com/kb/1112/userspace-networking/
-if [ -v TAILSCALE_USE_EXIT_NODE ]; then
+if [[ ${TAILSCALE_USERSPACE,,} =~ true|yes|on|1 ]] && [ -v TAILSCALE_USE_EXIT_NODE ]; then
     if [ -d /var/run/s6/container_environment ]; then
         printf "socks5://localhost:3215/" >/var/run/s6/container_environment/ALL_PROXY
         printf "socks5://localhost:3215/" >/var/run/s6/container_environment/all_proxy

--- a/docker-mod/root/etc/s6-overlay/s6-rc.d/tailscaled/run
+++ b/docker-mod/root/etc/s6-overlay/s6-rc.d/tailscaled/run
@@ -5,11 +5,26 @@
 
 set -euo pipefail
 
-FLAGS="--tun=userspace-networking"
+# handle unassigned variables
+TAILSCALE_USERSPACE="${TAILSCALE_USERSPACE:-true}"
+
+FLAGS=""
+
+if [[ ${TAILSCALE_USERSPACE,,} =~ true|yes|on|1 ]]; then
+    echo '[!] using userspace networking'
+    FLAGS="$FLAGS --tun=userspace-networking"
+else
+    echo '[!] using kernel networking'
+    modprobe tun || true
+    modprobe wireguard || true
+    mkdir -p /dev/net
+    [ ! -c /dev/net/tun ] && mknod /dev/net/tun c 10 200
+fi
 
 # https://github.com/tailscale-dev/docker-mod/pull/8#issuecomment-1792262196
 # https://tailscale.com/kb/1112/userspace-networking/
-if [ -v TAILSCALE_USE_EXIT_NODE ]; then
+if [[ ${TAILSCALE_USERSPACE,,} =~ true|yes|on|1 ]] && [ -v TAILSCALE_USE_EXIT_NODE ]; then
+    echo '[!] starting socks5 and http proxy servers on ports 3215 and 3214'
     FLAGS="$FLAGS --socks5-server=localhost:3215 --outbound-http-proxy-listen=localhost:3214"
 fi
 

--- a/docker-mod/root/etc/s6-overlay/s6-rc.d/tailscaled/run
+++ b/docker-mod/root/etc/s6-overlay/s6-rc.d/tailscaled/run
@@ -17,9 +17,20 @@ if [ -v TAILSCALE_STATE_DIR ]; then
     mkdir -p "${TAILSCALE_STATE_DIR}"
     FLAGS="$FLAGS --statedir=${TAILSCALE_STATE_DIR}"
 else
-    echo '[!] TAILSCALE_STATE_DIR is not set, this node will be ephemeral.'
     FLAGS="$FLAGS --state=mem:"
 fi
 
 # shellcheck disable=SC2086
-exec tailscaled $FLAGS 2>&1
+tailscaled $FLAGS 2>&1 &
+pid=$!
+
+# https://github.com/just-containers/s6-overlay/issues/545
+graceful_stop() {
+    # https://tailscale.com/kb/1080/cli/#down
+    tailscale down --accept-risk=all
+    kill -QUIT $pid
+}
+
+trap "graceful_stop; exit" SIGTERM SIGQUIT
+
+wait $pid


### PR DESCRIPTION
The option to keep tailscale state in memory
via --state=mem: doesn't work when generating
TLS certificates.

Using a path in container tmpfs is the next best thing.

Change-type: minor