### PR TITLE
Use printenv for DISABLE check to survive parser/builder skew

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ x-s6-service: &s6-service
     - -c
   command:
     - |
-      if [[ $${DISABLE,,} =~ true|yes|on|1 ]]; then
+      if printenv DISABLE | grep -qiE '^(true|yes|on|1)$'; then
         echo "DISABLE is truthy, exiting..."
         exit 0
       fi
@@ -218,7 +218,7 @@ services:
       - -c
     command:
       - |
-        if [[ $${DISABLE,,} =~ true|yes|on|1 ]]; then
+        if printenv DISABLE | grep -qiE '^(true|yes|on|1)$'; then
           echo "DISABLE is truthy, exiting..."
           exit 0
         fi


### PR DESCRIPTION
The CLI runs balena-compose-parser v25, which interpolates `$`-vars at parse time and needs `$$` to defer expansion to the runtime shell. The builder hasn't caught up — it doesn't collapse `$$` to `$`, so `$${DISABLE,,}` reaches bash literally and `$$` is read as the shell PID, breaking the check. Confirmed `$$` present at runtime in the dashboard.

Switching to `printenv DISABLE | grep -qiE` removes the `$` entirely, so it works regardless of which parser version runs. `grep -i` keeps the case-insensitivity that `,,` provided, and the anchored ERE fixes the previously unanchored substring match.

Ref: https://github.com/balena-io-modules/balena-compose-parser/issues/27